### PR TITLE
better disambiguation enhancement to handle both filename flatten collision and Wikipedia's own redirection

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -326,8 +326,8 @@ fn test_collision_handling_long_articles() -> Result<(), Box<dyn std::error::Err
     generate(config, NoCategorizer)?;
 
     let base_file = output_dir.join("tools/get_article/battle_article.json");
-    let variant1_file = output_dir.join("tools/get_article/battle_article_1.json");
-    let variant2_file = output_dir.join("tools/get_article/battle_article_2.json");
+    let variant1_file = output_dir.join("tools/get_article/battle_article__disambig_1.json");
+    let variant2_file = output_dir.join("tools/get_article/battle_article__disambig_2.json");
 
     assert!(base_file.exists());
     assert!(variant1_file.exists());
@@ -405,9 +405,9 @@ fn test_collision_handling_existing_disambiguation() -> Result<(), Box<dyn std::
     generate(config, NoCategorizer)?;
 
     let base_file = output_dir.join("tools/get_article/empire_article.json");
-    let variant1_file = output_dir.join("tools/get_article/empire_article_1.json");
-    let variant2_file = output_dir.join("tools/get_article/empire_article_2.json");
-    let variant3_file = output_dir.join("tools/get_article/empire_article_3.json");
+    let variant1_file = output_dir.join("tools/get_article/empire_article__disambig_1.json");
+    let variant2_file = output_dir.join("tools/get_article/empire_article__disambig_2.json");
+    let variant3_file = output_dir.join("tools/get_article/empire_article__disambig_3.json");
 
     assert!(base_file.exists());
     assert!(variant1_file.exists());
@@ -479,8 +479,8 @@ fn test_collision_handling_mixed_lengths() -> Result<(), Box<dyn std::error::Err
     generate(config, NoCategorizer)?;
 
     let base_file = output_dir.join("tools/get_article/revolution_article.json");
-    let variant1_file = output_dir.join("tools/get_article/revolution_article_1.json");
-    let variant2_file = output_dir.join("tools/get_article/revolution_article_2.json");
+    let variant1_file = output_dir.join("tools/get_article/revolution_article__disambig_1.json");
+    let variant2_file = output_dir.join("tools/get_article/revolution_article__disambig_2.json");
 
     assert!(base_file.exists());
     assert!(variant1_file.exists());


### PR DESCRIPTION
1. fix that collision redirect content ask to go `{PAGE_NAME} (1)` when it should be `{PAGE_NAME} 1` instead.
2. rename collision page to use `{PAGE_NAME}__disambig_1` naming instead of prevent further collision
3. change Wikipedia's own redirection page to add more details on using `get_articles` on the redirection
4. skip generating self-redirecting pages (after filename flattening) since that's an unnecessary duplicate / collision.